### PR TITLE
fix: point require calls to source file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fileinator",
   "version": "0.0.0",
   "description": "A simple utility to generate files with a specified size and random content.",
-  "main": "index.js",
+  "main": "lib/fileinator.js",
   "scripts": {
     "lint": "semistandard",
     "test": "c8 mocha",


### PR DESCRIPTION
```sh
$ node -p "require('fileinator')"
internal/modules/cjs/loader.js:330
      throw err;
      ^

Error: Cannot find module '/Users/stephen/dev/gcs-resumable-upload/node_modules/fileinator/index.js'. Please verify that the package.json has a valid "main" entry
```

😨 